### PR TITLE
Create article seed

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,8 @@
     "typeorm": "typeorm-ts-node-esm -d dist/infra/gateways/database/typeorm/data-source.js",
     "typeorm:migration:run": "pnpm run typeorm migration:run",
     "typeorm:migration:revert": "pnpm run typeorm migration:revert",
-    "typeorm:migrate:create": "typeorm migration:create"
+    "typeorm:migrate:create": "typeorm migration:create",
+    "typeorm:seed": "pnpm exec typeorm-extension seed:run -d dist/infra/gateways/database/typeorm/data-source.js"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/server/src/infra/gateways/database/typeorm/data-source.ts
+++ b/server/src/infra/gateways/database/typeorm/data-source.ts
@@ -8,10 +8,10 @@ export const dataSourceOptions: DataSourceOptions & SeederOptions = {
   username: process.env.DB_USER || 'admin',
   password: process.env.DB_PASSWORD || 'admin',
   database: process.env.DB_NAME || 'artisync-db',
-  entities: [`${__dirname}/modules/**/*.schema.js`],
-  migrations: [`${__dirname}/**/migrations/**/*.js`],
-  seeds: [`${__dirname}/**/seeds/**/*.js`],
-  factories: [`${__dirname}/**/factories/**/*.js`],
+  entities: ['dist/**/*.schema.{js,ts}', 'src/**/*.schema.{js,ts}'], // TODO: check why __dirname does not work here
+  migrations: [`${__dirname}/**/migrations/**/*.{js,ts}`],
+  seeds: [`${__dirname}/**/seeds/**/*.{js,ts}`],
+  factories: [`${__dirname}/**/factories/**/*.{js,ts}`],
   synchronize: false,
 };
 

--- a/server/src/infra/gateways/database/typeorm/data-source.ts
+++ b/server/src/infra/gateways/database/typeorm/data-source.ts
@@ -8,7 +8,7 @@ export const dataSourceOptions: DataSourceOptions & SeederOptions = {
   username: process.env.DB_USER || 'admin',
   password: process.env.DB_PASSWORD || 'admin',
   database: process.env.DB_NAME || 'artisync-db',
-  entities: ['dist/**/*.schema.{js,ts}', 'src/**/*.schema.{js,ts}'], // TODO: check why __dirname does not work here
+  entities: ['dist/**/*.schema.{js,ts}'], // TODO: check why __dirname does not work here
   migrations: [`${__dirname}/**/migrations/**/*.{js,ts}`],
   seeds: [`${__dirname}/**/seeds/**/*.{js,ts}`],
   factories: [`${__dirname}/**/factories/**/*.{js,ts}`],

--- a/server/src/infra/gateways/database/typeorm/factories/article.factory.ts
+++ b/server/src/infra/gateways/database/typeorm/factories/article.factory.ts
@@ -1,0 +1,13 @@
+import { setSeederFactory } from 'typeorm-extension';
+
+import { ArticleSchema } from 'src/modules/article/repository/typeorm/schema/article.schema';
+
+export default setSeederFactory(ArticleSchema, (faker) => {
+  return <ArticleSchema>{
+    title: faker.commerce.productName(),
+    author: faker.person.fullName(),
+    description: faker.commerce.productDescription(),
+    link: faker.internet.url(),
+    state: 'FINALIZADO',
+  };
+});

--- a/server/src/infra/gateways/database/typeorm/seeds/article.seed.ts
+++ b/server/src/infra/gateways/database/typeorm/seeds/article.seed.ts
@@ -1,0 +1,14 @@
+import { DataSource } from 'typeorm';
+import { Seeder, SeederFactoryManager } from 'typeorm-extension';
+
+import { ArticleSchema } from 'src/modules/article/repository/typeorm/schema/article.schema';
+
+export default class ArticleSeed implements Seeder {
+  public async run(
+    dataSource: DataSource,
+    factoryManager: SeederFactoryManager,
+  ): Promise<any> {
+    const articleFactory = await factoryManager.get(ArticleSchema);
+    await articleFactory.saveMany(10);
+  }
+}


### PR DESCRIPTION
Had a few problems with the data-source.ts config related to entities, found a way to make it work but I'm not sure why I had to change from `${__dirname}/**/*.schema.{js,ts}` to `dist/**/*.schema.{js,ts}`.