### PR TITLE
#28 - Add statusId FK to article

### DIFF
--- a/server/src/infra/database/migration/1700060308855-add-article-status-relation.ts
+++ b/server/src/infra/database/migration/1700060308855-add-article-status-relation.ts
@@ -1,0 +1,32 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    TableColumn,
+    TableForeignKey,
+} from 'typeorm';
+
+export class AddArticleStatusRelation1700060308855
+    implements MigrationInterface
+{
+    tableColumn = new TableColumn({
+        name: 'statusId',
+        type: 'uuid',
+    });
+
+    foreignKey = new TableForeignKey({
+        columnNames: ['statusId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'Status',
+        onDelete: 'CASCADE',
+    });
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn('Article', this.tableColumn);
+        await queryRunner.createForeignKey('Article', this.foreignKey);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('Article', this.tableColumn);
+        await queryRunner.dropForeignKey('Article', this.foreignKey);
+    }
+}

--- a/server/src/modules/article/article.module.ts
+++ b/server/src/modules/article/article.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserModule } from '../user/user.module';
 import { ArticleController } from './controller/article.controller';
 import { ArticleRepository } from './repository/article.repository';
 import { ArticleSchema } from './schema/article.schema';
 import { ArticleService } from './service/article.service';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([ArticleSchema])],
+    imports: [TypeOrmModule.forFeature([ArticleSchema]), UserModule],
     controllers: [ArticleController],
     providers: [ArticleService, ArticleRepository],
 })

--- a/server/src/modules/article/controller/article.controller.ts
+++ b/server/src/modules/article/controller/article.controller.ts
@@ -37,7 +37,6 @@ export class ArticleController {
 
     @Get('user/:userId')
     async getByUserId(@Param('userId') userId: string) {
-        console.log(userId);
         const result = await this.articleService.getByUserId(userId);
         return result;
     }

--- a/server/src/modules/article/controller/article.controller.ts
+++ b/server/src/modules/article/controller/article.controller.ts
@@ -35,6 +35,13 @@ export class ArticleController {
         return result;
     }
 
+    @Get('user/:userId')
+    async getByUserId(@Param('userId') userId: string) {
+        console.log(userId);
+        const result = await this.articleService.getByUserId(userId);
+        return result;
+    }
+
     @Patch(':id')
     async update(
         @Param('id') id: string,

--- a/server/src/modules/article/dto/create-article.dto.ts
+++ b/server/src/modules/article/dto/create-article.dto.ts
@@ -28,7 +28,8 @@ export class CreateArticleDto {
     @IsUUID()
     userId: string;
 
-    // statusId: string; // FK
+    @IsUUID()
+    statusId: string;
 
     // projectId?: string; // FK
 

--- a/server/src/modules/article/entity/article.entity.ts
+++ b/server/src/modules/article/entity/article.entity.ts
@@ -1,3 +1,4 @@
+import { Status } from 'src/modules/status/entity/status.entity';
 import { User } from 'src/modules/user/entity/user.entity';
 
 export class Article {
@@ -8,7 +9,8 @@ export class Article {
     author: string;
     user?: User; // FK
     userId: string;
-    // statusId: string; // FK
+    status?: Status; // FK
+    statusId: string;
     // projectId?: string; // FK
     createdAt?: Date;
     updatedAt?: Date;

--- a/server/src/modules/article/repository/article.repository.ts
+++ b/server/src/modules/article/repository/article.repository.ts
@@ -3,6 +3,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Article } from '../entity/article.entity';
 
+export type GetArticleOptions = {
+    id?: string;
+    userId?: string;
+};
+
 @Injectable()
 export class ArticleRepository {
     constructor(
@@ -15,8 +20,9 @@ export class ArticleRepository {
         return article;
     }
 
-    async getAll(): Promise<Article[]> {
-        return await this.articleRepository.find();
+    async getAll(options?: GetArticleOptions): Promise<Article[]> {
+        const opt = { where: { ...options } };
+        return await this.articleRepository.find(opt);
     }
 
     async getById(id: string): Promise<Article> {

--- a/server/src/modules/article/schema/article.schema.ts
+++ b/server/src/modules/article/schema/article.schema.ts
@@ -32,6 +32,9 @@ export const ArticleSchema = new EntitySchema<Article>({
         userId: {
             type: 'uuid',
         },
+        statusId: {
+            type: 'uuid',
+        },
         createdAt: {
             type: Date,
             createDate: true,
@@ -50,6 +53,16 @@ export const ArticleSchema = new EntitySchema<Article>({
             joinColumn: {
                 referencedColumnName: 'id',
                 name: 'userId',
+            },
+        },
+        status: {
+            type: 'many-to-one',
+            target: 'Status',
+            onDelete: 'CASCADE',
+            nullable: false,
+            joinColumn: {
+                referencedColumnName: 'id',
+                name: 'statusId',
             },
         },
     },

--- a/server/src/modules/article/service/article.service.ts
+++ b/server/src/modules/article/service/article.service.ts
@@ -1,11 +1,18 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { UserService } from 'src/modules/user/service/user.service';
 import { UpdateArticleDto } from '../dto/update-article.dto';
 import { Article } from '../entity/article.entity';
-import { ArticleRepository } from '../repository/article.repository';
+import {
+    ArticleRepository,
+    GetArticleOptions,
+} from '../repository/article.repository';
 
 @Injectable()
 export class ArticleService {
-    constructor(private readonly articleRepository: ArticleRepository) {}
+    constructor(
+        private readonly articleRepository: ArticleRepository,
+        private readonly userService: UserService,
+    ) {}
 
     async create(article: Article) {
         const result = await this.articleRepository.create(article);
@@ -15,6 +22,16 @@ export class ArticleService {
     async getAll() {
         const result = await this.articleRepository.getAll();
         return result;
+    }
+
+    async getByUserId(userId: string): Promise<Article[]> {
+        const user = await this.userService.getById(userId);
+        if (!user) throw new NotFoundException('User not found');
+
+        const options: GetArticleOptions = { userId: userId };
+        const articles = await this.articleRepository.getAll(options);
+
+        return articles;
     }
 
     async getById(id: string) {
@@ -33,8 +50,8 @@ export class ArticleService {
             description: updatedArticleData.description ?? article.description,
             link: updatedArticleData.link ?? article.link,
             author: updatedArticleData.author ?? article.author,
-            user: article.user,
             userId: article.userId,
+            statusId: updateArticleDto.statusId ?? article.statusId,
             createdAt: article.createdAt,
             updatedAt: new Date(),
         };


### PR DESCRIPTION
Closes #28.

An article must have a status, one article will only have one status at a time, but a status may be associated with multiple articles at once.

Future improvements:
- User may only add status created by himself (both on creation and edition of article)
- Define default status in case none is passed (probably `To read`)