### PR TITLE
#54 - Refactor repository get methods

### DIFF
--- a/server/src/modules/article/repository/article.repository.ts
+++ b/server/src/modules/article/repository/article.repository.ts
@@ -16,25 +16,31 @@ export class ArticleRepository {
     ) {}
 
     async create(article: Article): Promise<Article> {
-        await this.articleRepository.save(article);
-        return article;
+        const result = await this.articleRepository.save(article);
+        return result;
     }
 
-    async getAll(options?: GetArticleOptions): Promise<Article[]> {
-        const opt = { where: { ...options } };
-        return await this.articleRepository.find(opt);
+    async getAll(): Promise<Article[]> {
+        const result = await this.articleRepository.find();
+        return result;
     }
 
     async getById(id: string): Promise<Article> {
         const options = { where: { id } };
-        const article = await this.articleRepository.findOne(options);
-        return article;
+        const result = await this.articleRepository.findOne(options);
+        return result;
+    }
+
+    async getByUserId(userId: string): Promise<Article[]> {
+        const options = { where: { userId } };
+        const result = await this.articleRepository.find(options);
+        return result;
     }
 
     async update(article: Article): Promise<Article> {
         // TODO: Stop using save and use update instead
-        article = await this.articleRepository.save(article);
-        return article;
+        const result = await this.articleRepository.save(article);
+        return result;
     }
 
     async delete(id: string): Promise<void> {

--- a/server/src/modules/article/service/article.service.ts
+++ b/server/src/modules/article/service/article.service.ts
@@ -2,10 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { UserService } from 'src/modules/user/service/user.service';
 import { UpdateArticleDto } from '../dto/update-article.dto';
 import { Article } from '../entity/article.entity';
-import {
-    ArticleRepository,
-    GetArticleOptions,
-} from '../repository/article.repository';
+import { ArticleRepository } from '../repository/article.repository';
 
 @Injectable()
 export class ArticleService {
@@ -28,8 +25,7 @@ export class ArticleService {
         const user = await this.userService.getById(userId);
         if (!user) throw new NotFoundException('User not found');
 
-        const options: GetArticleOptions = { userId: userId };
-        const articles = await this.articleRepository.getAll(options);
+        const articles = await this.articleRepository.getByUserId(userId);
 
         return articles;
     }

--- a/server/src/modules/status/repository/status.repository.ts
+++ b/server/src/modules/status/repository/status.repository.ts
@@ -18,15 +18,15 @@ export class StatusRepository {
         return result;
     }
 
-    async getByUserId(userId: string): Promise<Status[]> {
-        const options = { where: { userId } };
-        const result = await this.statusRepository.find(options);
-        return result;
-    }
-
     async getById(id: string): Promise<Status> {
         const options = { where: { id } };
         const result = await this.statusRepository.findOne(options);
+        return result;
+    }
+
+    async getByUserId(userId: string): Promise<Status[]> {
+        const options = { where: { userId } };
+        const result = await this.statusRepository.find(options);
         return result;
     }
 


### PR DESCRIPTION
Closes #54 

Article had a generic get, refactored it and reordered methods from multiple repositories to follow this order:
- getAll
- getById
- domain specific gets