### PR TITLE
69 - Restrict username, email and password update through default endpoint

### DIFF
--- a/server/src/infra/database/migration/1700453795512-add-updated-username-date-to-user-table.ts
+++ b/server/src/infra/database/migration/1700453795512-add-updated-username-date-to-user-table.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddUpdatedUsernameDateToUserTable1700453795512
+    implements MigrationInterface
+{
+    tableColumn = new TableColumn({
+        name: 'updatedUsernameAt',
+        type: 'timestamp',
+        isNullable: true,
+    });
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn('User', this.tableColumn);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('User', this.tableColumn);
+    }
+}

--- a/server/src/modules/auth/service/auth.service.ts
+++ b/server/src/modules/auth/service/auth.service.ts
@@ -28,9 +28,7 @@ export class AuthService {
 
     async updateRefreshToken(userId: string, refreshToken: string) {
         const hashedRefreshToken = await this.argonHelper.hash(refreshToken);
-        await this.userService.update(userId, {
-            refreshToken: hashedRefreshToken,
-        });
+        await this.userService.refreshToken(userId, hashedRefreshToken);
     }
 
     generateTokens(userId: string): Tokens {
@@ -101,7 +99,7 @@ export class AuthService {
 
         const hashedNewPassword = await this.argonHelper.hash(newPassword);
 
-        await this.userService.update(user.id, { password: hashedNewPassword });
+        await this.userService.changePassword(user.id, hashedNewPassword);
     }
 
     async forgotPassword(forgotPasswordDto: ForgotPasswordDto): Promise<void> {
@@ -158,14 +156,13 @@ export class AuthService {
         await this.authRepository.invalidate(instance);
 
         const hashedPassword = await this.argonHelper.hash(password);
-        await this.userService.update(user.id, { password: hashedPassword });
+        await this.userService.changePassword(user.id, hashedPassword);
 
         await this.logout(user.id);
     }
 
     async logout(userId: string) {
-        // TODO: Add refreshtoken should not be null in order to logout
-        await this.userService.update(userId, { refreshToken: null });
+        await this.userService.refreshToken(userId, null);
     }
 
     async refresh(userId: string, refreshToken: string) {

--- a/server/src/modules/user/controller/user.controller.ts
+++ b/server/src/modules/user/controller/user.controller.ts
@@ -7,6 +7,7 @@ import {
     Patch,
     Query,
 } from '@nestjs/common';
+import { ChangeUsernameDto } from '../dto/change-username.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserService } from '../service/user.service';
 
@@ -20,7 +21,6 @@ export class UserController {
         return result;
     }
 
-    // TODO: See if there should exist a get all here
     @Get()
     async getByTextData(
         @Query('username') username: string,
@@ -33,7 +33,6 @@ export class UserController {
         return result;
     }
 
-    // TODO: Do not allow to update username, email and password by this endpoint
     @Patch(':id')
     async update(
         @Param('id') id: string,
@@ -41,6 +40,16 @@ export class UserController {
     ) {
         // TODO: Convert from UpdateUserDto to User
         const result = await this.userService.update(id, updateUserDto);
+        return result;
+    }
+
+    @Patch('change-username/:id')
+    async changeUsername(
+        @Param('id') id: string,
+        @Body() changeUsernameDto: ChangeUsernameDto,
+    ) {
+        const username = changeUsernameDto.username;
+        const result = await this.userService.changeUsername(id, username);
         return result;
     }
 

--- a/server/src/modules/user/dto/change-username.dto.ts
+++ b/server/src/modules/user/dto/change-username.dto.ts
@@ -1,0 +1,3 @@
+export class ChangeUsernameDto {
+    username: string;
+}

--- a/server/src/modules/user/dto/update-user.dto.ts
+++ b/server/src/modules/user/dto/update-user.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from './create-user.dto';
-
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
+export class UpdateUserDto {
+    bio?: string;
+    image?: string;
+}

--- a/server/src/modules/user/entity/user.entity.ts
+++ b/server/src/modules/user/entity/user.entity.ts
@@ -6,6 +6,7 @@ export class User {
     bio?: string;
     image?: string;
     refreshToken?: string;
+    updatedUsernameAt?: Date;
     createdAt?: Date;
     updatedAt?: Date;
 }

--- a/server/src/modules/user/schema/user.schema.ts
+++ b/server/src/modules/user/schema/user.schema.ts
@@ -37,6 +37,10 @@ export const UserSchema = new EntitySchema<User>({
             length: 510,
             nullable: true,
         },
+        updatedUsernameAt: {
+            type: Date,
+            nullable: true,
+        },
         createdAt: {
             type: Date,
             createDate: true,


### PR DESCRIPTION
Username update has its own endpoint and restriction of only allowing users to update every 90 days. Email cannot be updated under any circumstance. Password may be updated by other endpoints (e.g. `auth/change-password` and `auth/reset-password`)

Closes #69 and #68 