### PR TITLE
58 - Use create and update instead of save

### DIFF
--- a/server/src/modules/article/repository/article.repository.ts
+++ b/server/src/modules/article/repository/article.repository.ts
@@ -11,7 +11,7 @@ export class ArticleRepository {
     ) {}
 
     async create(article: Article): Promise<Article> {
-        const result = await this.articleRepository.save(article);
+        const result = await this.articleRepository.create(article);
         return result;
     }
 
@@ -33,8 +33,10 @@ export class ArticleRepository {
     }
 
     async update(article: Article): Promise<Article> {
-        // TODO: Stop using save and use update instead
-        const result = await this.articleRepository.save(article);
+        const result = (
+            await this.articleRepository.update(article.id, article)
+        ).raw[0];
+
         return result;
     }
 

--- a/server/src/modules/auth/repository/auth.repository.ts
+++ b/server/src/modules/auth/repository/auth.repository.ts
@@ -11,7 +11,7 @@ export class AuthRepository {
     ) {}
 
     async create(passwordReset: ResetPassword): Promise<ResetPassword> {
-        const result = await this.passwordResetRepository.save(passwordReset);
+        const result = await this.passwordResetRepository.create(passwordReset);
         return result;
     }
 
@@ -39,8 +39,9 @@ export class AuthRepository {
     }
 
     async invalidate(instance: ResetPassword): Promise<ResetPassword> {
-        // TODO: Stop using save and use update instead
-        const result = await this.passwordResetRepository.save(instance);
+        const result = (
+            await this.passwordResetRepository.update(instance.id, instance)
+        ).raw[0];
 
         return result;
     }

--- a/server/src/modules/status/repository/status.repository.ts
+++ b/server/src/modules/status/repository/status.repository.ts
@@ -9,7 +9,7 @@ export class StatusRepository {
     ) {}
 
     async create(status: Status): Promise<Status> {
-        const result = await this.statusRepository.save(status);
+        const result = await this.statusRepository.create(status);
         return result;
     }
 
@@ -31,8 +31,8 @@ export class StatusRepository {
     }
 
     async update(status: Status): Promise<Status> {
-        // TODO: Stop using save and use update instead
-        const result = await this.statusRepository.save(status);
+        const result = (await this.statusRepository.update(status.id, status))
+            .raw[0];
         return result;
     }
 

--- a/server/src/modules/user/repository/user.repository.ts
+++ b/server/src/modules/user/repository/user.repository.ts
@@ -11,7 +11,7 @@ export class UserRepository {
     ) {}
 
     async create(user: User): Promise<User> {
-        await this.userRepository.save(user);
+        await this.userRepository.create(user);
         return user;
     }
 
@@ -38,8 +38,7 @@ export class UserRepository {
     }
 
     async update(user: User): Promise<User> {
-        // TODO: Stop using save and use update instead
-        user = await this.userRepository.save(user);
+        user = (await this.userRepository.update(user.id, user)).raw[0];
         return user;
     }
 


### PR DESCRIPTION
Closes #58 

In update, `.raw[0]` must be returned in order to return the updated entity.